### PR TITLE
Replace RUN button with PAUSE while simulator is running

### DIFF
--- a/src/presentation/Console.svelte
+++ b/src/presentation/Console.svelte
@@ -61,6 +61,12 @@
         opacity: 0.4;
     }
 
+    @media (max-width: 1250px) {
+		#console-inner{
+            height: 80%;
+        }
+	}
+
     @media (max-width: 600px) {
 		#clear-console{
             font-size: 11px;

--- a/src/presentation/EditorView.svelte
+++ b/src/presentation/EditorView.svelte
@@ -178,7 +178,7 @@
 	}
 
 	#console-ctr{
-		max-height: 45vh;
+		max-height: 41vh;
 	}
 
 	#ev-buttons{
@@ -196,7 +196,7 @@
 		text-align: center;
 	}
 
-	@media (max-width: 1200px) {
+	@media (max-width: 1300px) {
 		.functionBtn{
 			font-size: 18px !important;
 		}
@@ -204,7 +204,7 @@
 		#editor-view{
 			display: grid;
 			grid-template-columns: 100%;
-			grid-template-rows: 90vh 90vh;
+			grid-template-rows: 90vh 85vh;
 		}
 
 		#ev-right{
@@ -216,7 +216,7 @@
 		}
 
 		#console-ctr{
-			max-height: 100%;
+			max-height: 95%;
 		}
 
 		#ev-buttons{
@@ -230,8 +230,9 @@
 		}
 
 		#ss-ctr{
-			margin: 4vh 5% 0 0;
+			margin: 2vh 5% 0 0;
 			transform: scale(1.1);
+			width: 25%;
 		}
 	}
 

--- a/src/presentation/SimulatorView.svelte
+++ b/src/presentation/SimulatorView.svelte
@@ -149,7 +149,7 @@
 			else if(control == "reload"){ 
 				// Reload procedure
 				globalThis.simulator.reloadProgram()
-            	currPtr = orig
+				currPtr = orig
 				pc = globalThis.simulator.getPC()
 				memMap = globalThis.simulator.getMemoryRange(currPtr, currPtr+longJumpOffset)
 				updateRegisters()
@@ -267,12 +267,12 @@
 	}
 
 	#c-ctr{
-		max-height: 25vh;
+		height: 25vh;
 	}
 
 	@media (max-width: 1300px) {
         #c-ctr{
-			max-height: 50vh;
+			height: 50vh;
 		}
 	}
 </style>

--- a/src/presentation/SimulatorView.svelte
+++ b/src/presentation/SimulatorView.svelte
@@ -14,7 +14,7 @@
     import JumpControls from "./JumpControls.svelte"
 	import SimulatorStatus from './SimulatorStatus.svelte'
 	import UI from './ui'
-	import { reloadOverride, UIReady } from './stores'
+	import { reloadOverride, UIReady, updateMainButton } from './stores'
 
 	// Preset data
 	let orig = 0
@@ -145,6 +145,16 @@
 			else if(control == "out"){ await globalThis.simulator.stepOut() }
 			else if(control == "over"){ await globalThis.simulator.stepOver() }
 			else if(control == "run"){ await globalThis.simulator.run()	}
+			else if(control == "pause"){ globalThis.simulator.halt() }
+			else if(control == "reload"){ 
+				// Reload procedure
+				globalThis.simulator.reloadProgram()
+            	currPtr = orig
+				pc = globalThis.simulator.getPC()
+				memMap = globalThis.simulator.getMemoryRange(currPtr, currPtr+longJumpOffset)
+				updateRegisters()
+				updateMainButton.set(0)
+			}
 		}
 	}
 

--- a/src/presentation/StepControls.svelte
+++ b/src/presentation/StepControls.svelte
@@ -58,13 +58,12 @@
 <style>
     #step-controls{
         height: max-content;
-        min-height: 15vh;
+        min-height: 14vh;
         display: grid;
-        grid-template-columns: 55% 30%;
-        grid-template-rows: 30% 30% 30%;
+        grid-template-columns: 50% 35%;
+        grid-template-rows: 31% 31% 31%;
         grid-column-gap: 15%;
         grid-row-gap: 3%;
-        margin-top: 1vh;
     }
 
     #run{
@@ -73,7 +72,7 @@
     }
 
     #step-in, #step-out, #step-over{
-        font-size: 15px;
+        font-size: 13px;
         text-align: left;
         border-radius: 10px;
         padding: 0.6em 0 0.6em 1.2em;
@@ -81,29 +80,34 @@
     }
 
     .functionBtn{
+        font-size: 20px;
 		text-align: center;
 	} 
 
     .functionBtn span{
-		margin-right: 4%;
+		margin-right: 8%;
 	}
 
     @media (max-width: 1300px) {
         #step-in, #step-out, #step-over{
-            font-size: 13px;
             padding-left: 0.8em;
         }
     }
 
     @media (max-width: 1000px) {
         #step-controls{
-            grid-template-rows: 4em 4em;
-            grid-template-columns: 30% 30% 30%;
+            grid-template-rows: 3.5em 3.5em;
+            grid-template-columns: 31% 31% 31%;
             grid-column-gap: 3%;
             grid-row-gap: 5%;
             margin-top: 1vh;
-            margin-bottom: 3vh;
+            margin-bottom: 2vh;
         }
+
+        .functionBtn{
+            font-size: 18px;
+		    text-align: center;
+	    } 
 
         #run{
             grid-row: 1/2;
@@ -112,8 +116,8 @@
 
         #step-in, #step-out, #step-over{
             text-align: center;
-            font-size: 12px;
-            padding: 0.2em 0 0.2em 0.2em;
+            font-size: 11px;
+            padding: 0.08em 0 0.08em 0.2em;
             display: flex;
             flex-direction: column;
             justify-content: center !important;
@@ -121,7 +125,6 @@
 
         .functionBtn span{
             margin-bottom: 4%;
-
         }
     }
 </style>

--- a/src/presentation/StepControls.svelte
+++ b/src/presentation/StepControls.svelte
@@ -4,8 +4,9 @@
 -->
 
 <script>
-    import { createEventDispatcher } from 'svelte';
-    const dispatch = createEventDispatcher();
+    import { updateMainButton } from './stores.js';
+    import { createEventDispatcher } from 'svelte'
+    const dispatch = createEventDispatcher()
 
     // Dispatch clicked control
     function step(control){
@@ -13,15 +14,32 @@
     }
 
     // Step control handlers
-    function runClick(){ step("run") }
+    function runClick(){
+        if (mainButton == 1) { step("pause") }
+        else if (mainButton == 2) { step("reload") }
+        else { step("run") } 
+    }
     function stepInClick(){ step("in") }
     function stepOutClick(){ step("out") }
     function stepOverClick(){ step("over") }
+
+    // Change main button text based on simulator activity    
+    let mainButtonText = "▶ RUN"
+    let mainButton = 0
+    updateMainButton.subscribe(value => { mainButton = value })
+
+    $: if (mainButton == 1)
+        mainButtonText = `<span class="material-symbols-outlined">pause</span> PAUSE`
+    else if (mainButton == 2)
+        mainButtonText = `↻ RELOAD`
+    else
+        mainButtonText = `▶ RUN`
+    
 </script>
 
 <div id="step-controls">
     <button id="run" class="functionBtn" on:click={runClick}>
-        ▶ RUN
+        {@html mainButtonText}
     </button>
     <button id="step-in" class="functionBtn" on:click={stepInClick}>
         <span class="material-symbols-outlined">subdirectory_arrow_right</span>

--- a/src/presentation/Workspace.svelte
+++ b/src/presentation/Workspace.svelte
@@ -28,7 +28,7 @@
 
 <style>
     #workspace{
-        margin-top: 6vh;
+        margin-top: 5vh;
         width: 100vw;
         height: 80vh;
         display: flex;
@@ -42,7 +42,7 @@
 
     @media (max-width: 1300px) {
 		#workspace{
-			height: 120vh;
+			height: 125vh;
 		}
 	}
 

--- a/src/presentation/stores.js
+++ b/src/presentation/stores.js
@@ -27,6 +27,9 @@ export const activeStoplight = writable("sim-status-not-ready")
 // Boolean: Simulator UI is ready to update
 export const UIReady = writable(false)
 
+// Integer: Change text in main step control button
+export const updateMainButton = writable(0)
+
 /* [Boolean, Boolean]:
  *  [0] - Enable Simulator Memory component reload
  *  [1] - Reset Memory pointer to .orig

--- a/src/presentation/ui.js
+++ b/src/presentation/ui.js
@@ -2,17 +2,18 @@
  * ui.js
  * 
  *  Functions to modify states for the following UI components
- *      - Console.svelte 
+ *      - Console.svelte
+ *      - SimulatorView.svelte 
  *      - SimulatorStatus.svelte
+ *      - StepControls.svelte
  */
 
-import { activeStoplight, consoleSelected, UIReady } from "./stores"
+import { activeStoplight, consoleSelected, UIReady, updateMainButton } from "./stores"
 
 // Signal that UI is ready to update
 function update(){
     UIReady.set(true)
 }
-
 
 // Replace all contents of Console with given string
 function printConsole(msg){
@@ -93,7 +94,6 @@ function modifyConsole(msg, append=false, clear=false){
         console.error("Console component not found in UI.")
 }
 
-
 // Set NOT READY on SimulatorStatus
 function setSimulatorNotReady(){
     activeStoplight.set("sim-status-not-ready")
@@ -103,14 +103,20 @@ function setSimulatorNotReady(){
 // Set READY on SimulatorStatus
 function setSimulatorReady(){
     activeStoplight.set("sim-status-ready")
+    updateMainButton.set(0)
 }
 
 
 // Set RUNNING on SimulatorStatus
 function setSimulatorRunning(){
     activeStoplight.set("sim-status-running")
+    updateMainButton.set(1)
 }
 
+// End Simulator
+function haltSimulator(){
+    updateMainButton.set(2)
+}
 
 export default {
     update,
@@ -121,5 +127,6 @@ export default {
     deselectConsole,
     setSimulatorNotReady,
     setSimulatorReady,
-    setSimulatorRunning
+    setSimulatorRunning,
+    haltSimulator
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,16 +19,9 @@
 
     function keyRelease(event) {
         if(globalThis.simulator && interruptable){
-            // Tilde (~) is used as the interrupt key to force stop a running simulator
-            if(event.key == '~')
-                globalThis.simulator.halt()
-            // Else, send key code to the simulator
-            else
-            {
-                const keyCode = KeyCodes.getAscii(event.key)
-                if (typeof(keyCode) != 'undefined')
-                    globalThis.simulator.keyboardInterrupt(keyCode)
-            }
+            const keyCode = KeyCodes.getAscii(event.key)
+            if (typeof(keyCode) != 'undefined')
+                globalThis.simulator.keyboardInterrupt(keyCode)
             
             reloadOverride.set([true,false])
         }


### PR DESCRIPTION
additional changes:
* remove pausing simulator by inputting `~` in console
* add support for a reload button appearing next to RUN once program gracefully halts (not yet implemented in simulator)