### PR TITLE
Fix bug when initiating traps/exceptions, optimize console output

### DIFF
--- a/src/logic/simulator/os/lc3_os.asm
+++ b/src/logic/simulator/os/lc3_os.asm
@@ -282,6 +282,7 @@ TRAP_HALT:
     STR     r1, r6, #1
     STR     r7, r6, #2
 
+HALT_LOOP:
     ; print message
     LEA     r0, HALT_MSG
     PUTS
@@ -289,10 +290,11 @@ TRAP_HALT:
     LD      r1, MSB_MASK
     LDI     r0, MCR
     AND     r0, r0, r1
-    STI     r0, MCR
-    ; excecution stops here
+    STI     r0, MCR     ; excecution stops here
+    
+    ; if clock is manually re-enabled, halt the computer again
+    BR      HALT_LOOP
 
-    ; in case the clock is manually re-enabled, return as normal
     LDR     r0, r6, #0
     LDR     r1, r6, #1
     LDR     r7, r6, #2

--- a/src/logic/simulator/simWorker.ts
+++ b/src/logic/simulator/simWorker.ts
@@ -506,12 +506,13 @@ class SimWorker
         this.setMemory(ssp - 2, this.getPC());
         Atomics.store(this.savedSSP, 0, ssp - 2);
 
-        // load R6 with supervisor stack if it is not the SSP already
+        // if we were in user mode, save R6 to savedUSP
         if (this.userMode())
         {
             Atomics.store(this.savedUSP, 0, this.getRegister(6));
-            this.setRegister(6, Atomics.load(this.savedSSP, 0));
         }
+        // in either case, set R6 to the value of the SSP
+        this.setRegister(6, Atomics.load(this.savedSSP, 0));
 
         // set privilege mode to supervisor (PSR[15] = 0)
         Atomics.and(this.psr, 0, this.CLEAR_USER);
@@ -535,12 +536,13 @@ class SimWorker
         this.setMemory(ssp - 2, this.getPC());
         Atomics.store(this.savedSSP, 0, ssp - 2);
 
-        // load R6 with supervisor stack if it is not the SSP already
+        // if we were in user mode, save R6 to savedUSP
         if (this.userMode())
         {
             Atomics.store(this.savedUSP, 0, this.getRegister(6));
-            this.setRegister(6, Atomics.load(this.savedSSP, 0));
         }
+        // in either case, set R6 to the value of the SSP
+        this.setRegister(6, Atomics.load(this.savedSSP, 0));
 
         // set privilege mode to supervisor (PSR[15] = 0)
         Atomics.and(this.psr, 0, this.CLEAR_USER);
@@ -566,12 +568,13 @@ class SimWorker
         this.setMemory(ssp - 2, this.getPC());
         Atomics.store(this.savedSSP, 0, ssp - 2);
 
-        // load R6 with supervisor stack if it is not the SSP already
+        // if we were in user mode, save R6 to savedUSP
         if (this.userMode())
         {
             Atomics.store(this.savedUSP, 0, this.getRegister(6));
-            this.setRegister(6, Atomics.load(this.savedSSP, 0));
         }
+        // in either case, set R6 to the value of the SSP
+        this.setRegister(6, Atomics.load(this.savedSSP, 0));
 
         // set privilege mode to supervisor (PSR[15] = 0)
         Atomics.and(this.psr, 0, this.CLEAR_USER);
@@ -715,7 +718,7 @@ class SimWorker
         {
             this.setRegister(6, Atomics.load(this.savedUSP, 0));
         }
-        // otheewise, load R6 with SPP
+        // otherwise, load R6 with SPP
         else
         {
             this.setRegister(6, Atomics.load(this.savedSSP, 0));


### PR DESCRIPTION
Changes in `simWorker.ts`:

Previously, when initiating a trap, interrupt or exception, if the simulator was already in supervisor mode, the internal SSP would be updated but R6 would not be. This caused the PSR and PC on the supervisor stack to be overwritten by service routines which pushed registers to the stack.

Console output is buffered up to 1024 characters before it is sent to the main thread in a message. The buffer is also flushed whenever the worker stops executing code (i.e. after `run`, `stepIn`, etc.).

Changes in `lc3_os.asm`:

To make simulator behavior more predictable, the `HALT` service routine will loop if the simulator is started again. This prevents unpredictable behavior from attempting to execute the contents of RAM after the `HALT` instruction.