### PR TITLE
Make assembly errors from Parser propogate to Assembler

### DIFF
--- a/src/logic/assembler/assembler.ts
+++ b/src/logic/assembler/assembler.ts
@@ -191,6 +191,7 @@ export default class Assembler
                     else
                     {
                         memory[pc] = 0;
+                        hasError = true;
                     }
                     ++pc;
                 }


### PR DESCRIPTION
Functions for parsing instructions in parser.ts were returning values that appeared valid instead of NaN, causing the Assembler to think there were no errors.