### PR TITLE
Display characters in simulator memory window in same place as code

### DIFF
--- a/src/logic/simulator/asciiDecoder.ts
+++ b/src/logic/simulator/asciiDecoder.ts
@@ -1,0 +1,30 @@
+/**
+ * decodeAscii.ts
+ * 
+ * Given a number, return a string representation of the ascii character it
+ * represents, or an empty string otherwise.
+ */
+
+export default class AsciiDecoder
+{
+    private static ctrlCodes = new Map([
+        [9,  "'\\t'"],
+        [10, "'\\n'"],
+        [13, "'\\r'"]
+    ]);
+
+    static decode(code: number): string
+    {
+        // printable ascii codes, ' ' to '~'
+        if (code >= 32 && code < 127)
+        {
+            return "'" + String.fromCharCode(code) + "'";
+        }
+        // if there's a control code for it, return that, otherwise return ""
+        else
+        {
+            const seq = this.ctrlCodes.get(code);
+            return typeof(seq) === "undefined" ? "" : seq;
+        }
+    }
+}

--- a/src/logic/simulator/simulator.ts
+++ b/src/logic/simulator/simulator.ts
@@ -429,6 +429,7 @@ export default class Simulator
         for (let i = 0; i < len; i++)
         {
             let addr = (i + start) % 0x1_0000;
+            let content = this.getMemory(addr);
             let code;
             if (this.userDisassembly.has(addr))
             {
@@ -438,14 +439,18 @@ export default class Simulator
             {
                 code = this.osDissassembly.get(addr);
             }
+            else if (content < 0x80)
+            {
+                code = "'" + String.fromCharCode(content) + "'";
+            }
             if (typeof(code) === "undefined")
             {
                 code = "";
             }
             res.push([
                 "0x" + addr.toString(16),
-                "0x" + this.getMemory(addr).toString(16),
-                this.getMemory(addr).toString(10),
+                "0x" + content.toString(16),
+                content.toString(10),
                 code
             ]);
         }

--- a/src/logic/simulator/simulator.ts
+++ b/src/logic/simulator/simulator.ts
@@ -10,6 +10,7 @@
 import Assembler from "../assembler/assembler";
 import UI from "../../presentation/ui";
 import Messages from "./simMessages";
+import AsciiDecoder from "./asciiDecoder";
 
 export default class Simulator
 {
@@ -439,10 +440,11 @@ export default class Simulator
             {
                 code = this.osDissassembly.get(addr);
             }
-            else if (content < 0x80)
+            else 
             {
-                code = "'" + String.fromCharCode(content) + "'";
+                code = AsciiDecoder.decode(content);
             }
+
             if (typeof(code) === "undefined")
             {
                 code = "";

--- a/src/logic/simulator/simulator.ts
+++ b/src/logic/simulator/simulator.ts
@@ -452,7 +452,7 @@ export default class Simulator
             res.push([
                 "0x" + addr.toString(16),
                 "0x" + content.toString(16),
-                content.toString(10),
+                this.signExtend(content).toString(10),
                 code
             ]);
         }
@@ -612,5 +612,26 @@ export default class Simulator
         Atomics.store(this.interruptVector, 0, 0);
         Atomics.store(this.savedSSP, 0, Simulator.SSP_DEFAULT);
         Atomics.store(this.savedUSP, 0, 0);
+    }
+
+    /**
+     * Sign-extend a 16-bit integer
+     */
+    public signExtend(num: number): number
+    {
+        // if it's positive, do not change it
+        if ((num & 0x8000) == 0)
+        {
+            return num;
+        }
+        else
+        {
+            // convert to positive 16-bit integer
+            num = ~num;
+            num += 1;
+            num &= 0xFFFF;
+            // return its negation
+            return -num;
+        }
     }
 }

--- a/src/presentation/SimulatorView.svelte
+++ b/src/presentation/SimulatorView.svelte
@@ -77,7 +77,7 @@
 				let regName = "R" + n
 				let regDec = globalThis.simulator.getRegister(n)
 				let regHex = "0x" + regDec.toString(16)
-				tempRegMap.push([regName, regHex, regDec.toString()])
+				tempRegMap.push([regName, regHex, globalThis.simulator.signExtend(regDec).toString()])
 			}
 			let cc = globalThis.simulator.getPSRInfo()[2]
 			let psrDec = globalThis.simulator.getPSR()


### PR DESCRIPTION
If a memory location does not contain LC-3 code, but it contains an ASCII character, the character will be displayed in the same place as the code would be.