### PR TITLE
Update package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-node": "^1.0.0-next.102",
-		"@sveltejs/kit": "next",
+		"@sveltejs/adapter-node": "^1.1.3",
+		"@sveltejs/kit": "^1.0.0",
 		"@types/express": "^4.17.14",
-		"svelte": "^3.44.0",
-		"svelte-check": "^2.7.1",
-		"typescript": "^4.7.4",
-		"vite": "^3.1.0"
+		"svelte": "^3.54.0",
+		"svelte-check": "^2.9.2",
+		"typescript": "^4.9.3",
+		"vite": "^4.0.0"
 	},
 	"type": "module",
 	"dependencies": {


### PR DESCRIPTION
After SvelteKit release, versions need to be updated for fresh app install to work