### PR TITLE
Fix using labels as operands in .FILL directives

### DIFF
--- a/src/logic/assembler/assembler.ts
+++ b/src/logic/assembler/assembler.ts
@@ -213,7 +213,7 @@ export default class Assembler
             } // end if 
         } // end white
 
-        // go back and fix branches label is always last operand
+        // go back and fix branches, label is always last operand
         for (const entry of toFix)
         {
             const tokens = entry[0];
@@ -240,7 +240,7 @@ export default class Assembler
                 }
                 else
                 {
-                    memory[loc] = labelVal;
+                    memory[loc] = labelVal + startOffset;
                 }
             }
             else if (tokens[0] == ".blkw")


### PR DESCRIPTION
Label value was being used without adding object file's starting offset